### PR TITLE
do not start traffic if given net or ifname not found

### DIFF
--- a/pkg/tgc/tgc.go
+++ b/pkg/tgc/tgc.go
@@ -434,14 +434,13 @@ func getAvailableNetBatPairings(namespace, podName, pairingStr string) ([]util.B
 			} else {
 				logrus.Errorf("no interface present for given source interface name %s", source.Interface)
 			}
-		} else if source.IP == "" {
-			// assign primary network eth0 interface ip address
+		} else {
+			// primary network, assign eth0 interface ip address
 			if srcIfaceIPAddress, ok := ifNameAddressMap["eth0"]; ok {
 				source.IP = srcIfaceIPAddress
 				source.Interface = "eth0"
 			} else {
-				logrus.Errorf("source doesn't have primary interface in the pair %s, ignoring", pair)
-				continue
+				logrus.Errorf("source doesn't have primary interface eth0 in the pair %s", pair)
 			}
 		}
 		elements = trimSlice(strings.Split(elements[1], ","))

--- a/pkg/tgc/tgc.go
+++ b/pkg/tgc/tgc.go
@@ -311,7 +311,9 @@ func (tg *podTGC) createNetBatTgenClients() {
 			p.ClientConnection = client
 			err = p.ClientConnection.SetupConnection()
 			if err != nil {
-				logrus.Errorf("error in setting up the connection for pair %v: %v", p, err)
+				source, _ := json.Marshal(p.Source)
+				logrus.Errorf("error in setting up the connection for pair %s-%v-%s-%s: %v", string(source),
+					*p.Destination, p.TrafficProfile, p.TrafficScenario, err)
 				return
 			}
 			go p.ClientConnection.HandleTimeouts()
@@ -420,13 +422,16 @@ func getAvailableNetBatPairings(namespace, podName, pairingStr string) ([]util.B
 				if srcIfaceIPAddress, ok := ifNameAddressMap[srcIface]; ok {
 					source.IP = srcIfaceIPAddress
 				}
+			} else {
+				logrus.Errorf("no interface present for given source network %s", source.Net)
 			}
 		} else if source.Interface != "" {
 			if srcIfaceIPAddress, ok := ifNameAddressMap[source.Interface]; ok {
 				source.IP = srcIfaceIPAddress
+			} else {
+				logrus.Errorf("no interface present for given source interface name %s", source.Interface)
 			}
-		}
-		if source.IP == "" {
+		} else if source.IP == "" {
 			// assign primary network eth0 interface ip address
 			if srcIfaceIPAddress, ok := ifNameAddressMap["eth0"]; ok {
 				source.IP = srcIfaceIPAddress

--- a/pkg/tgc/tgc.go
+++ b/pkg/tgc/tgc.go
@@ -417,12 +417,15 @@ func getAvailableNetBatPairings(namespace, podName, pairingStr string) ([]util.B
 			continue
 		}
 		if source.Net != "" {
+			ipFound := false
 			if srcIface, ok := netIfNameMap[namespace+"/"+source.Net]; ok {
 				source.Interface = srcIface
 				if srcIfaceIPAddress, ok := ifNameAddressMap[srcIface]; ok {
+					ipFound = true
 					source.IP = srcIfaceIPAddress
 				}
-			} else {
+			}
+			if !ipFound {
 				logrus.Errorf("no interface present for given source network %s", source.Net)
 			}
 		} else if source.Interface != "" {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -218,7 +218,11 @@ func RegisterPromHandler(promPort int, reg *prometheus.Registry) {
 }
 
 // GetResolvableAddress get resolvable address for given ip address
-func GetResolvableAddress(ip string) (address string) {
+func GetResolvableAddress(ip string) (address string, err error) {
+	if ip == "" {
+		err = errors.New("ip address can't be empty")
+		return
+	}
 	if IsIPv6(ip) {
 		address = "[" + ip + "]:0"
 	} else {


### PR DESCRIPTION
tgc by default assigns primary interface when given secondary network or interface not found, this commit makes those streams to be counted as not started.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>